### PR TITLE
PR-914 java_statsd dropping multi-line stats

### DIFF
--- a/src/main/java/org/devnull/statsd/UDPListener.java
+++ b/src/main/java/org/devnull/statsd/UDPListener.java
@@ -62,7 +62,7 @@ public class UDPListener implements Listener, Runnable
 
 				ArrayList<String> lines = new ArrayList<String>();
 
-				if (data.contains("\\n"))
+				if (data.contains("\n"))
 				{
 					Collections.addAll(lines, data.split("\\n"));
 				}

--- a/src/main/java/org/devnull/statsd/ZMQListener.java
+++ b/src/main/java/org/devnull/statsd/ZMQListener.java
@@ -91,7 +91,7 @@ public class ZMQListener implements Listener, Runnable
 
 				ArrayList<String> lines = new ArrayList<String>();
 
-				if (data.contains("\\n"))
+				if (data.contains("\n"))
 				{
 					Collections.addAll(lines, data.split("\\n"));
 				}


### PR DESCRIPTION
Tested on TS, confirmed that matches missed by \\n are picked up by \n.